### PR TITLE
add gradient interval forecast viz

### DIFF
--- a/2_process/src/temp_utils.R
+++ b/2_process/src/temp_utils.R
@@ -1,0 +1,6 @@
+f_to_c <- function(fahr) {
+  (5/9)*(fahr - 32)
+}
+c_to_f <- function(c){
+  (9/5)*c+32
+}

--- a/3_visualize/src/plot_gradient.R
+++ b/3_visualize/src/plot_gradient.R
@@ -37,7 +37,7 @@ plot_gradient <- function(ensemble_data, site_info, date_start, days_shown, out_
                size = .6,
                alpha = 0.8) +
     # panel for each site
-    facet_grid(~ site_name) + 
+    facet_grid(~ site_label) + 
     stat_gradientinterval(.width = c(0),
                           shape = NA,
                           width =.95,
@@ -71,20 +71,22 @@ plot_gradient <- function(ensemble_data, site_info, date_start, days_shown, out_
                ),
                shape = 21,
                stroke = 1,
-               size = 1.5, 
+               size = 1.25, 
                fill = "white") +
     theme(legend.position = "none",
-          axis.text=element_text(size=8, angle = 0, hjust = 0),
+          axis.text=element_text(size = 6, angle = 0, hjust = 1),
           strip.background = element_rect(color = NA, fill = NA),
+          # color for axis labels - throws an error, ignore that
           axis.text.y = element_text(color = c(rep("black", 4), "orangered", "black")),
-          panel.background = element_rect(color="grey", fill=NA),
+          panel.background = element_rect(color="grey", fill = NA),
           axis.line = element_line(size = .5, color="gray"),
           strip.text = element_text(face = "bold"))+
-    scale_y_continuous(position = "left") +
+    scale_y_continuous(position = "left",
+                       breaks = seq(55, 75, by = 5)) +
     scale_x_date(breaks = scales::breaks_width("1 day"),
                  labels = scales::label_date_short()) 
   
-  ggsave(out_file, width = 1600, height = 900, dpi = 300, units = "px")
+  ggsave(out_file, width = 1600, height = 600, dpi = 300, units = "px")
   
   return(out_file)
   

--- a/3_visualize/src/plot_gradient.R
+++ b/3_visualize/src/plot_gradient.R
@@ -1,0 +1,103 @@
+plot_gradient <- function(ensemble_data, site_info, date_start, days_shown){
+  
+  # filter data to a focal time period
+  date_start <- as.Date(date_start)
+  
+  threshold = 23.89 # C
+  
+  plot_df <- ensemble_data %>%
+    filter(model_name == 'DA') %>%
+    mutate(obs_max_temp_f = c_to_f(obs_max_temp_c),
+           pred_max_temp_f = c_to_f(max_temp)
+    ) %>%
+    # subset to time period of interest
+    filter(time %in% seq.Date(from = date_start, to = date_start+days_shown, by = "1 day")) %>%
+    # filter to 1 day out predictions only
+    filter(lead_time == 1) %>%
+    left_join(site_info)
+  
+  # observed max temp
+  temp_obs <- plot_df %>% 
+    distinct(time, site_name, site_label, obs_max_temp_f)
+  
+  # custom color scale 
+  start <- 42 # lower bound gradient
+  end <- c_to_f(threshold) # threshold
+  
+  # create gradient up until threshold
+  col_lapaz <- scico::scico(50, palette = "lapaz", direction = 1)[1:((1+end)-start)]  
+
+  # extend scale with 5 degree steps
+  deg_step <- 5
+  col_lapaz_ext <- c(rep("royalblue",deg_step), 
+                     rep("dodgerblue", deg_step),
+                     col_lapaz,
+                     rep("orangered",deg_step),
+                     rep("red", deg_step))
+
+  deg_num <- as.factor(c((start-(2*deg_step)):(end+(2*deg_step))))
+  names(col_lapaz_ext) <- deg_num
+  
+  
+  # plot 1-day out predictions with mean prediction and observed
+  plot_df %>%
+    ggplot(
+      aes(
+        x = time,
+        y = pred_max_temp_f,
+        group = site_name
+      )) +
+    labs(x = "",
+         y = "Max temperature (F)") +
+    # threshold line
+    geom_hline(yintercept = c_to_f(threshold),
+               linetype = "dashed",
+               color = "orangered",
+               size = .6,
+               alpha = 0.8) +
+    # panel for each site
+    facet_grid(~ site_name) + 
+    stat_gradientinterval(.width = c(.95),
+                          width =.95,
+                          # sub values over threshold with NA
+                          aes(fill = ifelse(stat(y) > c_to_f(threshold), NA, stat(y))), 
+                          fill_type = "gradient",
+                          size = 0.5) +
+    # gradient color scale, using red for NA (over threshold)
+    scico::scale_fill_scico(palette = "lapaz", 
+                            end = 0.75,
+                            na.value = "orangered") +
+    # tile to make observed temp
+    geom_tile(data = temp_obs,
+              aes(x = time,
+                  y = obs_max_temp_f,
+                  fill = obs_max_temp_f),  
+              size = 1,
+              height = .4,
+              width = .8,
+              alpha = 1,
+              color = NA) +
+    theme(legend.position = "none",
+          axis.text=element_text(size=8, angle = 0),
+          strip.background = element_rect(color = NA, fill = NA),
+          axis.text.y = element_text(color = c(rep("black", 4), "orangered", "black")),
+          panel.background = element_rect(color="grey", fill=NA),
+          axis.line = element_line(size = .5, color="gray"),
+          strip.text = element_text(face = "bold"))+
+    scale_y_continuous(position = "left") +
+    scale_x_date(breaks = scales::breaks_width("1 day"),
+                 labels = scales::label_date_short()) +
+    scale_fill_manual(values = c("darkgrey", "orangered"))+
+    geom_tile(data = temp_obs,
+                aes(x = time,
+                    y = obs_max_temp_f,
+                    ),  
+                size = 1,
+                height = .4,
+                width = .8,
+                alpha = 1,
+                color = NA)
+
+  
+}
+

--- a/3_visualize/src/plot_gradient.R
+++ b/3_visualize/src/plot_gradient.R
@@ -74,7 +74,7 @@ plot_gradient <- function(ensemble_data, site_info, date_start, days_shown, out_
                size = 1.25, 
                fill = "white") +
     theme(legend.position = "none",
-          axis.text=element_text(size = 6, angle = 0, hjust = 1),
+          axis.text=element_text(size = 6, angle = 0, hjust = 0.5),
           strip.background = element_rect(color = NA, fill = NA),
           # color for axis labels - throws an error, ignore that
           axis.text.y = element_text(color = c(rep("black", 4), "orangered", "black")),

--- a/_targets.R
+++ b/_targets.R
@@ -1,8 +1,12 @@
 library(targets)
 
 tar_option_set(packages = c(
-  'tidyverse'
+  'tidyverse',
+  'ggdist'
 ))
+
+source('2_process/src/temp_utils.R')
+source('3_visualize/src/plot_gradient.R')
 
 list(
 
@@ -13,14 +17,33 @@ list(
   #   https://code.usgs.gov/wma/wp/forecast-preprint-code/-/tree/main/in
   tar_target(p1_forecast_data_rds, '1_fetch/in/all_mods_with_obs.rds', format="file"),
   tar_target(p1_forecast_data, readRDS(p1_forecast_data_rds)),
+  
+  # Data with all ensembles
+  tar_target(p1_ensemble_data_rds, '1_fetch/in/da_noda_all_ensembles.rds', format="file"),
+  tar_target(p1_ensemble_data, readRDS(p1_ensemble_data_rds)),
 
   ##### Extract some metadata for potentially mapping over #####
 
   tar_target(p2_forecast_dates, unique(p1_forecast_data$time)),
   tar_target(p2_forecast_seg_ids, unique(p1_forecast_data$seg_id_nat)),
   tar_target(p2_forecast_model, unique(p1_forecast_data$model_name)),
-  tar_target(p2_forecast_scenario, unique(p1_forecast_data$scenario))
+  tar_target(p2_forecast_scenario, unique(p1_forecast_data$scenario)),
+  
+  tar_target(
+    p2_site_info,
+    p1_forecast_data %>%
+      filter(!is.na(site_name)) %>%
+      distinct(seg_id_nat, site_name) %>%
+      mutate(site_label = stringr::word(site_name, 3, -1))
+  ),
+  
 
-  ##### VISUALIZE DATA? #####
+  ##### VISUALIZE DATA #####
+  tar_target(
+    p3_daily_gradient_interval_png,
+    plot_gradient(p1_forecast_data,
+                  date_start = "2021-06-28",
+                  days_shown = 6)
+  )
 
 )

--- a/_targets.R
+++ b/_targets.R
@@ -44,7 +44,9 @@ list(
     plot_gradient(ensemble_data = p1_ensemble_data,
                   site_info = p2_site_info,
                   date_start = "2021-06-28",
-                  days_shown = 6)
+                  days_shown = 6,
+                  out_file = "3_visualize/out/daily_gradient_interval.png"),
+    format = "file"
   )
 
 )

--- a/_targets.R
+++ b/_targets.R
@@ -41,7 +41,8 @@ list(
   ##### VISUALIZE DATA #####
   tar_target(
     p3_daily_gradient_interval_png,
-    plot_gradient(p1_forecast_data,
+    plot_gradient(ensemble_data = p1_ensemble_data,
+                  site_info = p2_site_info,
                   date_start = "2021-06-28",
                   days_shown = 6)
   )


### PR DESCRIPTION
This adds the plotting code to produce the gradient interval forecast figure as a target `p3_daily_gradient_interval_png`. This uses all the ensemble data and plots the 1-day out forecasts given a start date and number of days to view:
![daily_gradient_interval](https://user-images.githubusercontent.com/17803537/165406074-f7b6dd1c-1c54-4626-949b-6a13bebca431.png)

The cool part of the plotting code is the gradient x threshold color ramp it uses mapped to the max temperature, `aes(fill = ifelse(stat(y) > c_to_f(threshold), NA, stat(y)))`. This pulls the data mapped to the y variable, uses an ifelse to replace values over the threshold as `NA`, and fills `NA`s with a different color in the scale layer. 