### PR TITLE
Add exceedance map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ _targets/*
 1_fetch/out/*
 1_fetch/in/*
 !*/*/.placeholder
+
+3_visualize/out/*

--- a/3_visualize/src/map_exceedance_prob.R
+++ b/3_visualize/src/map_exceedance_prob.R
@@ -1,0 +1,17 @@
+
+#' @description Map the river segments and style them to show the probability
+#' of each exceeding 75 degC the next day.
+map_exceedance_prob <- function(exceedance_data, segs_sf, out_file) {
+
+  ggsegmap <- segs_sf %>%
+    left_join(exceedance_data, by = 'seg_id_nat') %>%
+    ggplot(aes(color = prob_exceed_75, size = prob_exceed_75)) +
+    geom_sf() +
+    theme_void() + coord_sf() +
+    scico::scale_color_scico(name = "Probability of \nexceeding 75 degC\n ", palette = 'bilbao', midpoint = 0.50) +
+    scale_size_continuous(range = c(0,0.75)) +
+    guides(size=FALSE) # Turn off the legend for the linewidth key
+
+  ggsave(out_file, ggsegmap, width = 1600, height = 1600, dpi = 200, units = "px")
+  return(out_file)
+}

--- a/_targets.R
+++ b/_targets.R
@@ -45,18 +45,27 @@ list(
   ##### Create example data to mimic our 70-segment forecast data for now #####
 
   tar_target(
-    p2_forecast_data_allsegs_madeup,
-    p1_forecast_data %>%
-      filter(model_name == 'DA') %>%
-      filter(lead_time == 1) %>%
-      filter(scenario == "+0cfs") %>%
-      # Force the data to be one row per seg & replace seg ids
-      # and be data all for the same dates
-      dplyr::slice(seq_along(p2_forecast_seg_ids)) %>%
-      mutate(seg_id_nat = p2_forecast_seg_ids,
-             issue_time = head(issue_time,1),
-             time = head(time,1),
-             site_name = NA)
+    p2_forecast_data_allsegs_madeup, {
+      madeup_data <- p1_forecast_data %>%
+        filter(model_name == 'DA') %>%
+        filter(lead_time == 1) %>%
+        filter(scenario == "+0cfs") %>%
+        # Force the data to be one row per seg & replace seg ids
+        # and be data all for the same dates
+        dplyr::slice(seq_along(p2_forecast_seg_ids)) %>%
+        mutate(seg_id_nat = p2_forecast_seg_ids,
+               issue_time = head(issue_time,1),
+               time = head(time,1),
+               site_name = NA)
+      # Don't want all 0s for exceedance to test mapping
+      set.seed(19)
+      madeup_data$prob_exceed_75 <- sample(seq(0,1,by=0.01), nrow(madeup_data))
+      return(madeup_data)
+    }
+  ),
+  tar_target(
+    p2_exceedance_data,
+    p2_forecast_data_allsegs_madeup %>% select(seg_id_nat, time, prob_exceed_75)
   ),
 
   ##### VISUALIZE DATA #####

--- a/_targets.R
+++ b/_targets.R
@@ -8,6 +8,7 @@ tar_option_set(packages = c(
 
 source('2_process/src/temp_utils.R')
 source('3_visualize/src/plot_gradient.R')
+source('3_visualize/src/map_exceedance_prob.R')
 
 list(
 
@@ -76,6 +77,14 @@ list(
                   date_start = "2021-06-28",
                   days_shown = 6,
                   out_file = "3_visualize/out/daily_gradient_interval.png"),
+    format = "file"
+  ),
+
+  tar_target(
+    p3_seg_exceedance_map_png,
+    map_exceedance_prob(exceedance_data = p2_exceedance_data,
+                        segs_sf = p1_forecast_segs_sf,
+                        out_file = "3_visualize/out/map_segment_exceedance_prob.png"),
     format = "file"
   )
 

--- a/_targets.R
+++ b/_targets.R
@@ -24,13 +24,13 @@ list(
   tar_target(p1_ensemble_data, readRDS(p1_ensemble_data_rds)),
 
   # Load spatial segment data
-  tar_target(p1_forcast_segs_shape_rds, '1_fetch/in/forecast_segs_shape.rds', format="file"),
-  tar_target(p1_forcast_segs_sf, readRDS(p1_forcast_segs_shape_rds)),
+  tar_target(p1_forecast_segs_shape_rds, '1_fetch/in/forecast_segs_shape.rds', format="file"),
+  tar_target(p1_forecast_segs_sf, readRDS(p1_forecast_segs_shape_rds)),
 
   ##### Extract some metadata for potentially mapping over #####
 
   tar_target(p2_forecast_dates, unique(p1_forecast_data$time)),
-  tar_target(p2_forecast_seg_ids, unique(p1_forcast_segs_sf$seg_id_nat)),
+  tar_target(p2_forecast_seg_ids, unique(p1_forecast_segs_sf$seg_id_nat)),
   tar_target(p2_forecast_model, unique(p1_forecast_data$model_name)),
   tar_target(p2_forecast_scenario, unique(p1_forecast_data$scenario)),
 


### PR DESCRIPTION
An initial map for showing the probability of different segments exceeding 75 degC using 1-day ahead. Edited our dummy data so that there were more than just 0s in the `prob_exceed_75` column (so these are totally false values). I encoded color and linewidth to the exceedance probability. I know that isn't viz best practice but I wanted a way to emphasize those that are at a higher probability more.

`tar_make(p3_seg_exceedance_map_png)` produces this file, `3_visualize/out/map_segment_exceedance_prob.png`

![map_segment_exceedance_prob](https://user-images.githubusercontent.com/13220910/166008089-05d1fb49-a1a9-49dc-a198-fe2af62fee81.png)
