### PR TITLE
plot 1-day out forecasts with CI

### DIFF
--- a/2_process/src/prep_intervals.R
+++ b/2_process/src/prep_intervals.R
@@ -1,0 +1,44 @@
+
+#' @description Reshape data for use with 'geom_slabinterval' family from ggdist
+#' @param ci_data forecast data filtered to 1-day out lead time
+#' @param plot_date focal date for 1-day out forecasts
+#' @param ci_list a list of confidence intervals to find upper and lower bounds 
+#' must be a 0.1 degree increment ranging 0.1-0.9
+prep_intervals <- function(ci_data, plot_date, ci_list){
+  
+  # filter data to focal date, 1-day out predictions
+  ci_interval <- ci_data %>% 
+    mutate(lead_time = time - issue_time) %>%
+    filter(model_name == 'DA') %>%
+    filter(lead_time == 1 & time == plot_date) %>%
+    select(seg_id_nat, threshold, quantile) %>%
+    # convert percentile increments to upper and lower bounds
+    mutate(interval = case_when(
+      threshold > 0.5 ~ '.upper', 
+      threshold < 0.5 ~ '.lower',
+      threshold == 0.5 ~ 'median'),
+      .width = case_when(
+        interval == '.upper' ~ (threshold - 0.5)*2,
+        interval == '.lower' ~ (0.5 - threshold)*2,
+        TRUE ~ threshold
+      ))
+
+  # find central tendancy
+  ci_median <- ci_interval %>%
+    filter(interval == 'median') %>%
+    rename(.point = interval, temp = quantile) %>%
+    select(seg_id_nat, temp, .point)
+
+  # Reshape data for input to ggdist geom_interval family
+  ci_wide <- ci_interval %>%
+    filter(interval != 'median', .width %in% ci_list) %>% 
+    select(-threshold) %>% 
+    transform(.width = as.factor(.width)) %>%
+    pivot_wider(id_cols = c('seg_id_nat', '.width'), 
+                names_from = interval, 
+                values_from = quantile) %>%
+    left_join(ci_median)
+  
+  return(ci_wide)
+
+}

--- a/2_process/src/prep_intervals.R
+++ b/2_process/src/prep_intervals.R
@@ -2,9 +2,7 @@
 #' @description Reshape data for use with 'geom_slabinterval' family from ggdist
 #' @param ci_data forecast data filtered to 1-day out lead time
 #' @param plot_date focal date for 1-day out forecasts
-#' @param ci_list a list of confidence intervals to find upper and lower bounds 
-#' must be a 0.1 degree increment ranging 0.1-0.9
-prep_intervals <- function(ci_data, plot_date, ci_list){
+prep_intervals <- function(ci_data, plot_date){
   
   # filter data to focal date, 1-day out predictions
   ci_interval <- ci_data %>% 
@@ -31,7 +29,7 @@ prep_intervals <- function(ci_data, plot_date, ci_list){
 
   # Reshape data for input to ggdist geom_interval family
   ci_wide <- ci_interval %>%
-    filter(interval != 'median', .width %in% ci_list) %>% 
+    filter(interval != 'median') %>%
     select(-threshold) %>% 
     transform(.width = as.factor(.width)) %>%
     pivot_wider(id_cols = c('seg_id_nat', '.width'), 

--- a/2_process/src/prep_intervals.R
+++ b/2_process/src/prep_intervals.R
@@ -10,6 +10,7 @@ prep_intervals <- function(ci_data, plot_date){
     filter(model_name == 'DA') %>%
     filter(lead_time == 1 & time == plot_date) %>%
     select(seg_id_nat, threshold, quantile) %>%
+    mutate(quantile = c_to_f(quantile)) %>%
     # convert percentile increments to upper and lower bounds
     mutate(interval = case_when(
       threshold > 0.5 ~ '.upper', 

--- a/3_visualize/src/map_exceedance_prob.R
+++ b/3_visualize/src/map_exceedance_prob.R
@@ -4,13 +4,15 @@
 map_exceedance_prob <- function(exceedance_data, segs_sf, out_file) {
 
   ggsegmap <- segs_sf %>%
+    transform(seg_id_nat = as.character(seg_id_nat)) %>%
     left_join(exceedance_data, by = 'seg_id_nat') %>%
     ggplot(aes(color = prob_exceed_75, size = prob_exceed_75)) +
     geom_sf() +
-    theme_void() + coord_sf() +
+    theme_void() + 
+    coord_sf() +
     scico::scale_color_scico(name = "Probability of \nexceeding 75 degC\n ", palette = 'bilbao', midpoint = 0.50) +
     scale_size_continuous(range = c(0,0.75)) +
-    guides(size=FALSE) # Turn off the legend for the linewidth key
+    guides(size = "none") # Turn off the legend for the linewidth key
 
   ggsave(out_file, ggsegmap, width = 1600, height = 1600, dpi = 200, units = "px")
   return(out_file)

--- a/3_visualize/src/plot_daily_ci.R
+++ b/3_visualize/src/plot_daily_ci.R
@@ -6,24 +6,43 @@
 #' must be a 0.1 degree increment ranging 0.1-0.9
 plot_daily_ci <- function(ci_interval_data, ci_list, plot_date, out_file){
   
-  ci_interval_data %>%
+  max_temp <- max(ci_interval_data$.upper)
+  
+  p <- ci_interval_data %>%
     filter(.width %in% ci_list) %>%
-    ggplot(aes(x = seg_id_nat,
+    ggplot(aes(y = reorder(seg_id_nat, temp),
                group = seg_id_nat,
-               y = temp,
-               ymin = .lower, ymax = .upper
+               x = temp,
+               xmin = .lower, xmax = .upper
     )) +
-    geom_interval() +
-    geom_point(color = 'white') +
+    geom_interval(
+      aes(
+        #interval_color = ..y..
+      )
+    ) +
+    geom_tile(fill = 'white',
+              width = 0.1) +
     theme_ci()+
     scale_color_brewer() +
-    labs(x = 'Stream segment', y = 'Temperature (C)')
+    labs(y = 'Stream Segment', x = 'Predicted Stream Temperature (F)') +
+    scale_x_continuous(position = 'top') +
+    guides(fill = guide_legend(
+      
+    ))
   
-  ggsave(out_file, width = 1600, height = 900, dpi = 200, units = "px")
+  if ( max_temp > 70){
+    plot_final <- p +
+      geom_vline(xintercept = 74, linetype = "dotted")
+  } else {
+    plot_final <- p
+  }
+  
+  ggsave(plot = plot_final, filename = out_file, height = 2400, width = 1500, dpi = 200, units = "px")
   return(out_file)
 }
 
 theme_ci <- function(){
-  theme_classic(base_size = 12)+
-    theme()
+  theme_classic(base_size = 14)+
+    theme(legend.position = c(0.8, 0.1),
+          axis.title = element_text(hjust = 0, face = "bold", lineheight = 1.5))
 }

--- a/3_visualize/src/plot_daily_ci.R
+++ b/3_visualize/src/plot_daily_ci.R
@@ -1,7 +1,7 @@
 
 #' @description Plot of single lead time for temperature predictions across many sites
 #' showing confidence intervals around predictions
-#' @param ci_data forecast data filtered to 1-day out lead time
+#' @param ci_interval_data forecast data filtered to 1-day out lead time; output of `prep_intervals()`
 #' @param ci_list a list of confidence intervals to find upper and lower bounds 
 #' must be a 0.1 degree increment ranging 0.1-0.9
 plot_daily_ci <- function(ci_interval_data, ci_list, plot_date, out_file){

--- a/3_visualize/src/plot_daily_ci.R
+++ b/3_visualize/src/plot_daily_ci.R
@@ -4,6 +4,8 @@
 #' @param ci_interval_data forecast data filtered to 1-day out lead time; output of `prep_intervals()`
 #' @param ci_list a list of confidence intervals to find upper and lower bounds 
 #' must be a 0.1 degree increment ranging 0.1-0.9
+#' @param plot_date focal date for 1-day out forecasts
+#' @param out_file filepath for saving the plot
 plot_daily_ci <- function(ci_interval_data, ci_list, plot_date, out_file){
   
   max_temp <- max(ci_interval_data$.upper)

--- a/3_visualize/src/plot_daily_ci.R
+++ b/3_visualize/src/plot_daily_ci.R
@@ -1,0 +1,29 @@
+
+#' @description Plot of single lead time for temperature predictions across many sites
+#' showing confidence intervals around predictions
+#' @param ci_data forecast data filtered to 1-day out lead time
+#' @param ci_list a list of confidence intervals to find upper and lower bounds 
+#' must be a 0.1 degree increment ranging 0.1-0.9
+plot_daily_ci <- function(ci_interval_data, ci_list, plot_date, out_file){
+  
+  ci_interval_data %>%
+    filter(.width %in% ci_list) %>%
+    ggplot(aes(x = seg_id_nat,
+               group = seg_id_nat,
+               y = temp,
+               ymin = .lower, ymax = .upper
+    )) +
+    geom_interval() +
+    geom_point(color = 'white') +
+    theme_ci()+
+    scale_color_brewer() +
+    labs(x = 'Stream segment', y = 'Temperature (C)')
+  
+  ggsave(out_file, width = 1600, height = 900, dpi = 200, units = "px")
+  return(out_file)
+}
+
+theme_ci <- function(){
+  theme_classic(base_size = 12)+
+    theme()
+}

--- a/_targets.R
+++ b/_targets.R
@@ -100,7 +100,7 @@ list(
   tar_target(
     p3_daily_ci_png,
     plot_daily_ci(ci_interval_data = p2_daily_ci_data,
-                  ci_list = c(0.5, 0.9), 
+                  ci_list = c(0.5, 0.8, 0.9), 
                   plot_date = p2_focal_date,
                   out_file = "3_visualize/out/daily_ci.png"),
     format = 'file'

--- a/_targets.R
+++ b/_targets.R
@@ -10,6 +10,8 @@ source('2_process/src/temp_utils.R')
 source('3_visualize/src/plot_gradient.R')
 source('3_visualize/src/map_exceedance_prob.R')
 
+site_lordville <- 1573
+
 list(
 
   ##### Download forecasting model outputs #####
@@ -29,6 +31,7 @@ list(
   tar_target(p1_eval_data, readRDS(p1_eval_data_rds)),
 
   # Load spatial segment data
+  # These files came from Sam
   tar_target(p1_forecast_segs_shape_rds, '1_fetch/in/forecast_segs_shape.rds', format="file"),
   tar_target(p1_forecast_segs_sf, readRDS(p1_forecast_segs_shape_rds)),
   
@@ -52,30 +55,13 @@ list(
       mutate(site_label = stringr::word(site_name, 3, -1))
   ),
 
-  ##### Create example data to mimic our 70-segment forecast data for now #####
-
-  tar_target(
-    p2_forecast_data_allsegs_madeup, {
-      madeup_data <- p1_forecast_data %>%
-        filter(model_name == 'DA') %>%
-        filter(lead_time == 1) %>%
-        filter(scenario == "+0cfs") %>%
-        # Force the data to be one row per seg & replace seg ids
-        # and be data all for the same dates
-        dplyr::slice(seq_along(p2_forecast_seg_ids)) %>%
-        mutate(seg_id_nat = p2_forecast_seg_ids,
-               issue_time = head(issue_time,1),
-               time = head(time,1),
-               site_name = NA)
-      # Don't want all 0s for exceedance to test mapping
-      set.seed(19)
-      madeup_data$prob_exceed_75 <- sample(seq(0,1,by=0.01), nrow(madeup_data))
-      return(madeup_data)
-    }
-  ),
   tar_target(
     p2_exceedance_data,
-    p2_forecast_data_allsegs_madeup %>% select(seg_id_nat, time, prob_exceed_75)
+    p1_forecast_data %>% 
+      filter(model_name == 'DA') %>%
+      filter(lead_time == 1) %>%
+      filter(scenario == "+0cfs") %>%
+      select(seg_id_nat, time, prob_exceed_75)
   ),
 
   ##### VISUALIZE DATA #####

--- a/_targets.R
+++ b/_targets.R
@@ -23,15 +23,19 @@ list(
   # Data with calculated 5% CI intervals for ensembles
   tar_target(p1_ci_data_rds, '1_fetch/in/all_mods_with_obs.rds', format="file"),
   tar_target(p1_ci_data, readRDS(p1_ci_data_rds)),
-
-  # OLD DATA `da_noda_all_ensembles.rds` with all ensembles used for gradient intervals 
-  # https://code.usgs.gov/wma/wp/forecast-preprint-code/-/tree/main/in
-  tar_target(p1_ensemble_data_rds, '1_fetch/in/da_noda_all_ensembles.rds', format="file"),
-  tar_target(p1_ensemble_data, readRDS(p1_ensemble_data_rds)),
+  
+  # Model eval
+  tar_target(p1_eval_data_rds, '1_fetch/in/forecast_model_eval.rds', format="file"),
+  tar_target(p1_eval_data, readRDS(p1_eval_data_rds)),
 
   # Load spatial segment data
   tar_target(p1_forecast_segs_shape_rds, '1_fetch/in/forecast_segs_shape.rds', format="file"),
   tar_target(p1_forecast_segs_sf, readRDS(p1_forecast_segs_shape_rds)),
+  
+  # OLD DATA `da_noda_all_ensembles.rds` with all ensembles used for gradient intervals 
+  # https://code.usgs.gov/wma/wp/forecast-preprint-code/-/tree/main/in
+  tar_target(p1_ensemble_data_rds, '1_fetch/in/da_noda_all_ensembles.rds', format="file"),
+  tar_target(p1_ensemble_data, readRDS(p1_ensemble_data_rds)),
 
   ##### Extract some metadata for potentially mapping over #####
 

--- a/_targets.R
+++ b/_targets.R
@@ -13,6 +13,7 @@ source('3_visualize/src/plot_daily_ci.R')
 source('3_visualize/src/map_exceedance_prob.R')
 
 site_lordville <- 1573
+focal_date <- '2021-07-04'
 
 list(
 

--- a/_targets.R
+++ b/_targets.R
@@ -15,11 +15,16 @@ list(
 
   # For now, this is a manual process where we download the
   #   files from this GitLab repo to the `1_fetch/in` folder
-  #   https://code.usgs.gov/wma/wp/forecast-preprint-code/-/tree/main/in
+  #   https://code.usgs.gov/wma/wp/forecast-preprint-code/-/tree/fy22_preprint/in
   tar_target(p1_forecast_data_rds, '1_fetch/in/all_mods_with_obs.rds', format="file"),
   tar_target(p1_forecast_data, readRDS(p1_forecast_data_rds)),
+  
+  # Data with calculated 5% CI intervals for ensembles
+  tar_target(p1_ci_data_rds, '1_fetch/in/all_mods_with_obs.rds', format="file"),
+  tar_target(p1_ci_data, readRDS(p1_ci_data_rds)),
 
-  # Data with all ensembles
+  # OLD DATA `da_noda_all_ensembles.rds` with all ensembles used for gradient intervals 
+  # https://code.usgs.gov/wma/wp/forecast-preprint-code/-/tree/main/in
   tar_target(p1_ensemble_data_rds, '1_fetch/in/da_noda_all_ensembles.rds', format="file"),
   tar_target(p1_ensemble_data, readRDS(p1_ensemble_data_rds)),
 


### PR DESCRIPTION
Adding targets to add new preprint data, prep data to plot with `geom_slabinterval` family from `ggdist`, and plot 1-day out predictions with provided confidence intervals. Produces:
![daily_ci](https://user-images.githubusercontent.com/17803537/169194760-83bfd3cd-1fab-4d96-b58a-ee3b5e6b5322.png)

The sites are currently sorted by the median prediction. The color intervals represent the 50%, 80% and 90% confidence intervals around the median value. The plotting function takes any CI from 0.1-0.9 in 0.1 steps (i.e. 0.1, 0.2, 0.3, 0.4, 05. 0.,6...). 

Will need to think more about how to use color in a useful way - if we want correspondence between a map and a chart like this, color will likely be important to share between the two and may limit how it can be used to show the intervals here.