### PR TITLE
mobile/twitter layout with 2 rows

### DIFF
--- a/3_visualize/src/merge_plot_legend.R
+++ b/3_visualize/src/merge_plot_legend.R
@@ -12,21 +12,21 @@ merge_plot_legend <- function(main_plot, legend, out_file, show_all_predicted){
           axis.ticks.y = element_blank())
   
   # Draw a blank spot "NULL" to put legend
-  plot_grid(main_plot, NULL, rel_widths = c(5,1))+
+  plot_grid(main_plot)+
     # then add legend on top
-    draw_plot(legend_updated, x = 0.83, y = 0.1, width = 0.08, height = 0.8)+
+    draw_plot(legend_updated, x = 0.75, y = 0.0, width = 0.093, height = 0.5)+
     # and annotate temperature threshold
-    draw_label(expression('75'~degree*'F'), colour = "orangered", x = .95, y = .75, size = 8)+
-    annotate("segment", xend = 0.903, x = 0.92, yend = 0.62, y = 0.69, 
+    draw_label(expression('75'~degree*'F'), colour = "orangered", x = .865, y = .37, size = 8)+
+    annotate("segment", xend = 0.82, x = 0.835, yend = 0.30, y = 0.34, 
              arrow = arrow(length = unit(0.1, "cm")), colour = "orangered")+
-    draw_label("threshold", x = .96, y = .705, size = 6, colour = "orangered")+
+    draw_label("threshold", x = .873, y = .338, size = 6, colour = "orangered")+
     # and annotate mean
-    draw_label("Mean", colour = "black", x = 0.95, y = 0.545, size = 7)+
-    annotate("segment", xend = 0.905, x = 0.92, yend = 0.545, y = 0.545, 
+    draw_label("Mean", colour = "black", x = 0.864, y = 0.258 , size = 7)+
+    annotate("segment", xend = 0.824, x = 0.837, yend = 0.258 , y = 0.258 , 
              arrow = arrow(length = unit(0.1, "cm")), colour = "black")+
     # and 90% CI
-    draw_label("{", x = 0.9, y = 0.47, size = 18, angle = 180, color = "black")+
-    draw_label("\u00B1 90% CI", colour = "black", x = 0.95, y = 0.49, size = 7)+
+    draw_label("{", x = 0.82, y = 0.208, size = 19, angle = 180, color = "black")+
+    draw_label("\u00B1 90% CI", colour = "black", x = 0.878, y = 0.225, size = 7)+
     # and complete values
     {if(show_all_predicted == TRUE){
       draw_label("     Predicted \nvalues", x = 0.93, y = 0.3, 
@@ -40,5 +40,5 @@ merge_plot_legend <- function(main_plot, legend, out_file, show_all_predicted){
   
   
   ggsave(filename = out_file,
-         width = 1600, height = 600, dpi = 300, units = "px", bg = "white")
+         width = 1600, height = 900, dpi = 300, units = "px", bg = "white")
 }

--- a/3_visualize/src/merge_plot_legend.R
+++ b/3_visualize/src/merge_plot_legend.R
@@ -1,4 +1,4 @@
-merge_plot_legend <- function(main_plot, legend, out_file, show_all_predicted){
+merge_plot_legend <- function(main_plot, legend, out_file, show_all_predicted, tworow_layout){
   
   # Add labels and annotation to legend before combining
   legend_updated <- legend +
@@ -12,33 +12,65 @@ merge_plot_legend <- function(main_plot, legend, out_file, show_all_predicted){
           axis.ticks.y = element_blank())
   
   # Draw a blank spot "NULL" to put legend
-  plot_grid(main_plot)+
-    # then add legend on top
-    draw_plot(legend_updated, x = 0.75, y = 0.0, width = 0.093, height = 0.5)+
-    # and annotate temperature threshold
-    draw_label(expression('75'~degree*'F'), colour = "orangered", x = .865, y = .37, size = 8)+
-    annotate("segment", xend = 0.82, x = 0.835, yend = 0.30, y = 0.34, 
-             arrow = arrow(length = unit(0.1, "cm")), colour = "orangered")+
-    draw_label("threshold", x = .873, y = .338, size = 6, colour = "orangered")+
-    # and annotate mean
-    draw_label("Mean", colour = "black", x = 0.864, y = 0.258 , size = 7)+
-    annotate("segment", xend = 0.824, x = 0.837, yend = 0.258 , y = 0.258 , 
-             arrow = arrow(length = unit(0.1, "cm")), colour = "black")+
-    # and 90% CI
-    draw_label("{", x = 0.82, y = 0.208, size = 19, angle = 180, color = "black")+
-    draw_label("\u00B1 90% CI", colour = "black", x = 0.878, y = 0.225, size = 7)+
-    # and complete values
-    {if(show_all_predicted == TRUE){
-      draw_label("     Predicted \nvalues", x = 0.93, y = 0.3, 
-                 size = 6, color = "cornsilk3")
-    } else {
-      draw_label("     Predicted \nvalues", x = 0.93, y = 0.3, 
-                 size = 6, color = "white")
-    }
-    }
-    
+  
+  
+  if(tworow_layout == T){
+    plot_grid(main_plot)+
+      # then add legend on top
+      draw_plot(legend_updated, x = 0.75, y = 0.0, width = 0.093, height = 0.5)+
+      # and annotate temperature threshold
+      draw_label(expression('75'~degree*'F'), colour = "orangered", x = .865, y = .37, size = 8)+
+      annotate("segment", xend = 0.82, x = 0.835, yend = 0.30, y = 0.34, 
+               arrow = arrow(length = unit(0.1, "cm")), colour = "orangered")+
+      draw_label("threshold", x = .873, y = .338, size = 6, colour = "orangered")+
+      # and annotate mean
+      draw_label("Mean", colour = "black", x = 0.864, y = 0.258 , size = 7)+
+      annotate("segment", xend = 0.824, x = 0.837, yend = 0.258 , y = 0.258 , 
+               arrow = arrow(length = unit(0.1, "cm")), colour = "black")+
+      # and 90% CI
+      draw_label("{", x = 0.82, y = 0.208, size = 19, angle = 180, color = "black")+
+      draw_label("\u00B1 90% CI", colour = "black", x = 0.878, y = 0.225, size = 7)+
+      # and complete values
+      {if(show_all_predicted == TRUE){
+        draw_label("     Predicted \nvalues", x = 0.93, y = 0.3, 
+                   size = 6, color = "cornsilk3")
+      } else {
+        draw_label("     Predicted \nvalues", x = 0.93, y = 0.3, 
+                   size = 6, color = "white")
+      }
+      }
+  } else {
+    plot_grid(main_plot, NULL, rel_widths = c(5,1))+
+      # then add legend on top
+      draw_plot(legend_updated, x = 0.83, y = 0.0, width = 0.08, height = 0.8)+
+      # and annotate temperature threshold
+      draw_label(expression('75'~degree*'F'), colour = "orangered", x = .95, y = .75, size = 8)+
+      annotate("segment", xend = 0.903, x = 0.92, yend = 0.62, y = 0.69, 
+               arrow = arrow(length = unit(0.1, "cm")), colour = "orangered")+
+      draw_label("threshold", x = .96, y = .705, size = 6, colour = "orangered")+
+      # and annotate mean
+      draw_label("Mean", colour = "black", x = 0.95, y = 0.545 , size = 7)+
+      annotate("segment", xend = 0.905, x = 0.92, yend = 0.545 , y = 0.545 , 
+               arrow = arrow(length = unit(0.1, "cm")), colour = "black")+
+      # and 90% CI
+      draw_label("{", x = 0.9, y = 0.47, size = 18, angle = 180, color = "black")+
+      draw_label("\u00B1 90% CI", colour = "black", x = 0.95, y = 0.49, size = 7)+
+      # and complete values
+      {if(show_all_predicted == TRUE){
+        draw_label("     Predicted \nvalues", x = 0.93, y = 0.3, 
+                   size = 6, color = "cornsilk3")
+      } else {
+        draw_label("     Predicted \nvalues", x = 0.93, y = 0.3, 
+                   size = 6, color = "white")
+      }
+      }
+  }
+  
+  
   
   
   ggsave(filename = out_file,
-         width = 1600, height = 900, dpi = 300, units = "px", bg = "white")
+         width = 1600, 
+         height = ifelse(tworow_layout == T, 900,600), 
+         dpi = 300, units = "px", bg = "white")
 }

--- a/3_visualize/src/merge_plot_legend.R
+++ b/3_visualize/src/merge_plot_legend.R
@@ -14,22 +14,22 @@ merge_plot_legend <- function(main_plot, legend, out_file, show_all_predicted, t
   # Draw a blank spot "NULL" to put legend
   
   
-  if(tworow_layout == T){
+  if(tworow_layout == T){    #### two row layout annotations
     plot_grid(main_plot)+
       # then add legend on top
       draw_plot(legend_updated, x = 0.75, y = 0.0, width = 0.093, height = 0.5)+
       # and annotate temperature threshold
-      draw_label(expression('75'~degree*'F'), colour = "orangered", x = .865, y = .37, size = 8)+
-      annotate("segment", xend = 0.82, x = 0.835, yend = 0.30, y = 0.34, 
+      draw_label(expression('75'~degree*'F'), colour = "orangered", x = .865, y = .39, size = 8)+
+      annotate("segment", xend = 0.82, x = 0.835, yend = 0.32, y = 0.36, 
                arrow = arrow(length = unit(0.1, "cm")), colour = "orangered")+
-      draw_label("threshold", x = .873, y = .338, size = 6, colour = "orangered")+
+      draw_label("threshold", x = .873, y = .358, size = 6, colour = "orangered")+
       # and annotate mean
-      draw_label("Mean", colour = "black", x = 0.864, y = 0.258 , size = 7)+
-      annotate("segment", xend = 0.824, x = 0.837, yend = 0.258 , y = 0.258 , 
+      draw_label("Mean", colour = "black", x = 0.864, y = 0.278 , size = 7)+
+      annotate("segment", xend = 0.824, x = 0.837, yend = 0.278 , y = 0.278 , 
                arrow = arrow(length = unit(0.1, "cm")), colour = "black")+
       # and 90% CI
-      draw_label("{", x = 0.82, y = 0.208, size = 19, angle = 180, color = "black")+
-      draw_label("\u00B1 90% CI", colour = "black", x = 0.878, y = 0.225, size = 7)+
+      draw_label("{", x = 0.82, y = 0.228, size = 19, angle = 180, color = "black")+
+      draw_label("\u00B1 90% CI", colour = "black", x = 0.878, y = 0.245, size = 7)+
       # and complete values
       {if(show_all_predicted == TRUE){
         draw_label("     Predicted \nvalues", x = 0.93, y = 0.3, 
@@ -39,22 +39,22 @@ merge_plot_legend <- function(main_plot, legend, out_file, show_all_predicted, t
                    size = 6, color = "white")
       }
       }
-  } else {
+  } else {           #### one row layout annotations
     plot_grid(main_plot, NULL, rel_widths = c(5,1))+
       # then add legend on top
       draw_plot(legend_updated, x = 0.83, y = 0.0, width = 0.08, height = 0.8)+
       # and annotate temperature threshold
-      draw_label(expression('75'~degree*'F'), colour = "orangered", x = .95, y = .75, size = 8)+
-      annotate("segment", xend = 0.903, x = 0.92, yend = 0.62, y = 0.69, 
+      draw_label(expression('75'~degree*'F'), colour = "orangered", x = .95, y = .60, size = 8)+
+      annotate("segment", xend = 0.903, x = 0.92, yend = 0.53, y = 0.58, 
                arrow = arrow(length = unit(0.1, "cm")), colour = "orangered")+
-      draw_label("threshold", x = .96, y = .705, size = 6, colour = "orangered")+
+      draw_label("threshold", x = .96, y = .555, size = 6, colour = "orangered")+
       # and annotate mean
-      draw_label("Mean", colour = "black", x = 0.95, y = 0.545 , size = 7)+
-      annotate("segment", xend = 0.905, x = 0.92, yend = 0.545 , y = 0.545 , 
+      draw_label("Mean", colour = "black", x = 0.95, y = 0.45 , size = 7)+
+      annotate("segment", xend = 0.905, x = 0.92, yend = 0.45 , y = 0.45 , 
                arrow = arrow(length = unit(0.1, "cm")), colour = "black")+
       # and 90% CI
-      draw_label("{", x = 0.9, y = 0.47, size = 18, angle = 180, color = "black")+
-      draw_label("\u00B1 90% CI", colour = "black", x = 0.95, y = 0.49, size = 7)+
+      draw_label("{", x = 0.9, y = 0.375, size = 18, angle = 180, color = "black")+
+      draw_label("\u00B1 90% CI", colour = "black", x = 0.95, y = 0.38 , size = 7)+
       # and complete values
       {if(show_all_predicted == TRUE){
         draw_label("     Predicted \nvalues", x = 0.93, y = 0.3, 

--- a/3_visualize/src/plot_interval.R
+++ b/3_visualize/src/plot_interval.R
@@ -19,7 +19,7 @@ plot_interval <- function(plot_gradient_df, threshold, show_all_predicted){
     labs(x = "",
          y = "Max temperature (F)") +
     # panel for each site
-    facet_grid(~ site_label) + {
+    facet_wrap(~ site_label, ncol = 3, scales = "free_x") + {
       # Turn off or on the full background of predicted values depending on argument
       if(show_all_predicted == TRUE){
         stat_gradientinterval(shape = NA,
@@ -31,7 +31,7 @@ plot_interval <- function(plot_gradient_df, threshold, show_all_predicted){
                               size = 1) }
     } +
     stat_interval(.width = seq(0.1, 0.9, by = 0.1), #set CI levels
-                  size = 2) +
+                  size = 3) +
     # gradient color scale, using red for NA (over threshold)
     scico::scale_fill_scico_d(palette = "lapaz", 
                               end = 0.7,
@@ -60,19 +60,21 @@ plot_interval <- function(plot_gradient_df, threshold, show_all_predicted){
         }}+
     theme(legend.position = "none",
           axis.text = element_text(angle = 0, hjust = 0.5),
-          axis.text.x = element_text(size = 5),
+          axis.text.x = element_text(size = 6),
           axis.ticks.x = element_line(size = 0.3),
           strip.background = element_rect(color = NA, fill = NA),
           # color for axis labels
-          axis.text.y = element_text(size = 5, color = ifelse(breaks_draw == 75, "red", "black")),
+          axis.text.y = element_text(size = 6, color = ifelse(breaks_draw == 75, "red", "black")),
           axis.ticks.y = element_line(color = ifelse(breaks_draw == 75, "red", "black"), size = 0.3),
           panel.background = element_rect(color="grey", fill = NA),
           axis.line = element_line(size = .5, color="gray"),
-          strip.text = element_text(face = "bold"),
+          strip.text = element_text(face = "bold", size = 8),
           # panel.grid left white marks over facet borders, removed with line below
           panel.grid = element_blank(),
           axis.title.y = element_text(size = 8),
-          panel.spacing = unit(0,"lines"))+
+          axis.title.x = element_blank(),
+          panel.spacing.x = unit(0.2,"lines"),
+          panel.spacing.y = unit(0, "lines"))+
     scale_y_continuous(position = "left",
                        breaks = seq(55, 75, by = 5)) +
     scale_x_date(breaks = scales::breaks_width("1 day"),

--- a/3_visualize/src/plot_interval.R
+++ b/3_visualize/src/plot_interval.R
@@ -1,4 +1,4 @@
-plot_interval <- function(plot_gradient_df, threshold, show_all_predicted){
+plot_interval <- function(plot_gradient_df, threshold, show_all_predicted, tworow_layout){
   
   # Max temperature for check if it's within range of threshold
   max_temp <- plot_gradient_df %>%
@@ -17,9 +17,13 @@ plot_interval <- function(plot_gradient_df, threshold, show_all_predicted){
         group = site_name
       )) +
     labs(x = "",
-         y = "Max temperature (F)") +
-    # panel for each site
-    facet_wrap(~ site_label, ncol = 3, scales = "free_x") + {
+         y = "Max temperature (F)") + {
+           if(tworow_layout == T){
+             facet_wrap(~ site_label, ncol = 3, scales = "free_x")
+           } else{
+             facet_wrap(~ site_label, ncol = 5)
+           }
+         } + {
       # Turn off or on the full background of predicted values depending on argument
       if(show_all_predicted == TRUE){
         stat_gradientinterval(shape = NA,
@@ -31,7 +35,7 @@ plot_interval <- function(plot_gradient_df, threshold, show_all_predicted){
                               size = 1) }
     } +
     stat_interval(.width = seq(0.1, 0.9, by = 0.1), #set CI levels
-                  size = 3) +
+                  size = 2) +
     # gradient color scale, using red for NA (over threshold)
     scico::scale_fill_scico_d(palette = "lapaz", 
                               end = 0.7,
@@ -60,21 +64,19 @@ plot_interval <- function(plot_gradient_df, threshold, show_all_predicted){
         }}+
     theme(legend.position = "none",
           axis.text = element_text(angle = 0, hjust = 0.5),
-          axis.text.x = element_text(size = 6),
+          axis.text.x = element_text(size = 5),
           axis.ticks.x = element_line(size = 0.3),
           strip.background = element_rect(color = NA, fill = NA),
           # color for axis labels
-          axis.text.y = element_text(size = 6, color = ifelse(breaks_draw == 75, "red", "black")),
+          axis.text.y = element_text(size = 5, color = ifelse(breaks_draw == 75, "red", "black")),
           axis.ticks.y = element_line(color = ifelse(breaks_draw == 75, "red", "black"), size = 0.3),
           panel.background = element_rect(color="grey", fill = NA),
           axis.line = element_line(size = .5, color="gray"),
-          strip.text = element_text(face = "bold", size = 8),
+          strip.text = element_text(face = "bold"),
           # panel.grid left white marks over facet borders, removed with line below
           panel.grid = element_blank(),
           axis.title.y = element_text(size = 8),
-          axis.title.x = element_blank(),
-          panel.spacing.x = unit(0.2,"lines"),
-          panel.spacing.y = unit(0, "lines"))+
+          panel.spacing = unit(0, "lines"))+
     scale_y_continuous(position = "left",
                        breaks = seq(55, 75, by = 5)) +
     scale_x_date(breaks = scales::breaks_width("1 day"),

--- a/_targets.R
+++ b/_targets.R
@@ -144,14 +144,16 @@ list(
     p3_daily_interval,
     plot_interval(p2_plot_gradient_df,
                   threshold = threshold_C,
-                  show_all_predicted = show_all_predicted)
+                  show_all_predicted = show_all_predicted,
+                  tworow_layout = F)
   ),
   tar_target(
     # create legend, filter to just one example date and location
     p3_daily_interval_legend,
     plot_interval(plot_gradient_df = readRDS(p2_plot_legend_file),
                   threshold = threshold_C,
-                  show_all_predicted = show_all_predicted)
+                  show_all_predicted = show_all_predicted,
+                  tworow_layout = F)
   ),
   tar_target(
     # save plot
@@ -159,7 +161,27 @@ list(
     merge_plot_legend(main_plot = p3_daily_interval,
                       legend = p3_daily_interval_legend,
                       show_all_predicted = show_all_predicted,
-                      out_file = "3_visualize/out/daily_interval.png"),
+                      out_file = "3_visualize/out/daily_interval.png",
+                      tworow_layout = F),
+    format = "file"
+  ),
+  
+  tar_target(
+    # create plot with 2-rows
+    p3_daily_interval_2row,
+    plot_interval(p2_plot_gradient_df,
+                  threshold = threshold_C,
+                  show_all_predicted = show_all_predicted,
+                  tworow_layout = T)
+  ),
+  tar_target(
+    # save plot
+    p3_daily_interval_2row_png,
+    merge_plot_legend(main_plot = p3_daily_interval_2row,
+                      legend = p3_daily_interval_legend,
+                      show_all_predicted = show_all_predicted,
+                      out_file = "3_visualize/out/daily_interval_2row.png",
+                      tworow_layout = T),
     format = "file"
   ),
   


### PR DESCRIPTION
I updated the interval plot to be displayed in two rows regarding issue #21. This included increasing axis text size, putting a little bit of spacing back in between panels, and moving legend around. Final image (1600 x 900 size):

![daily_interval](https://user-images.githubusercontent.com/19958841/175342273-2ce2d898-b756-4faa-bf7c-d75d6e9584ba.png)

